### PR TITLE
Set state.bot property to "Copy always"

### DIFF
--- a/SDKV4-Samples/dotnet_core/StateBot/StateBot.csproj
+++ b/SDKV4-Samples/dotnet_core/StateBot/StateBot.csproj
@@ -9,6 +9,13 @@
 
 
   <ItemGroup>
+    <Content Include="state.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+
+   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />


### PR DESCRIPTION
This is critical for having the bot work when it is deployed to Azure. Without it, "Test in Web Chat" hangs forever with "Waiting for bot to be ready". The other projects in this group of dotnet_core bot samples are correct. This is the only one that lacks the setting.
Best, Bruce.